### PR TITLE
feat: Time based rotation for Todos

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/web/src/features/dashboard/Dashboard.tsx
+++ b/web/src/features/dashboard/Dashboard.tsx
@@ -4,6 +4,7 @@ import shallow from 'zustand/shallow'
 import { Button } from "../../components/Button";
 import { DAILY, MONTHLY, WEEKLY } from "../../helpers/colorDeterminer";
 import { useTodoStore } from "../../helpers/store";
+import { Type } from "../../interfaces/todo";
 import { MainStats } from "./MainStats";
 import { TodoSection } from "./TodoSection";
 
@@ -15,9 +16,9 @@ const Dashboard = () => {
         <div className="flex flex-col content-between h-full justify-between">
             <div>
                 <MainStats todos={todos} />
-                <TodoSection todos={groupedTodosByType[DAILY]} type={DAILY} />
-                <TodoSection todos={groupedTodosByType[WEEKLY]} type={WEEKLY} />
-                <TodoSection todos={groupedTodosByType[MONTHLY]} type={MONTHLY} />
+                <TodoSection todos={groupedTodosByType[DAILY]} type={Type.daily} />
+                <TodoSection todos={groupedTodosByType[WEEKLY]} type={Type.weekly} />
+                <TodoSection todos={groupedTodosByType[MONTHLY]} type={Type.monthly} />
             </div>
             <div className="w-full flex justify-between mb-10">
                 <Link to="todo/template"><Button text="Template" /></Link>

--- a/web/src/features/dashboard/TodoSection.tsx
+++ b/web/src/features/dashboard/TodoSection.tsx
@@ -2,19 +2,22 @@ import { filter, isEmpty, map, partition, size } from "lodash";
 import { useState } from "react";
 import { TodoListItem } from "../../components/TodoListItem";
 import { getColorTheme } from "../../helpers/colorDeterminer";
-import { Todo } from "../../interfaces/todo";
+import { filterDateForType } from "../../helpers/date";
+import { Todo, Type } from "../../interfaces/todo";
 import { TodoSectionHeader } from "./TodoSectionHeader";
 
 interface Props {
     todos: Todo[],
-    type: string,
-}
+    type: Type,
+}   
 
 const TodoSection = ({ todos, type }: Props) => {
     const [showDone, toggleTodoView] = useState(false);
     const color = getColorTheme(type);
-    const amountDone = size(filter(todos, (todo: Todo) => todo.completedAt));
-    const [doneTodos, uncompletedTodos] = partition(todos, todo => todo.completedAt);
+    const todosForTimeSpan = filter(todos, todo => filterDateForType(type, todo.createdAt));
+    const [doneTodos, uncompletedTodos] = partition(todosForTimeSpan, todo => todo.completedAt);
+
+    
 
     if (isEmpty(todos)) {
         return null;
@@ -22,7 +25,7 @@ const TodoSection = ({ todos, type }: Props) => {
 
     return (
         <div className="mb-6">
-            <TodoSectionHeader total={size(todos)} done={amountDone} backgroundColor={color.bg.light} onToggleTodoView={() => toggleTodoView(!showDone)} showDone={showDone} />
+            <TodoSectionHeader total={size(todos)} done={size(doneTodos)} backgroundColor={color.bg.light} onToggleTodoView={() => toggleTodoView(!showDone)} showDone={showDone} />
             <div className="space-y-4">
                 {map(showDone ? doneTodos : uncompletedTodos, todo => <TodoListItem key={todo.id} todo={todo} color={color.decorationColor} />)}
             </div>

--- a/web/src/features/history/History.tsx
+++ b/web/src/features/history/History.tsx
@@ -6,7 +6,6 @@ import { useTodoStore } from "../../helpers/store";
 
 const History = () => {
     const { type = 'daily' } = useParams();
-    console.log({type})
     const todos = useTodoStore(state => state.getTodoByType(type));
     const completedTodos = filter(todos, todo => todo.createdAt);
 

--- a/web/src/features/todoFlow/OneTimeFlow.tsx
+++ b/web/src/features/todoFlow/OneTimeFlow.tsx
@@ -55,7 +55,7 @@ const OneTimeFlow = () => {
             id: uuidv4(),
             taskId: taskData.oneTimeOnly.id,
             title: todoBuilderData.title,
-            createdAt: '28-10-22',
+            createdAt: Date.now(),
             type: todoBuilderData.type,
             description: todoBuilderData.description
         }

--- a/web/src/features/todoFlow/TemplateFlow.tsx
+++ b/web/src/features/todoFlow/TemplateFlow.tsx
@@ -9,7 +9,6 @@ import { CategoryStep } from "./CategoryStep";
 import { TaskStep } from "./TaskStep";
 import { TypeStep } from "./TypeStep";
 import { DescriptionStep } from "./DescriptionStep";
-import { now } from "lodash";
 
 const TYPE_STEP = 'TYPE';
 const CATEGORY_STEP = 'CATEGORY';
@@ -64,7 +63,6 @@ const TemplateFlow = () => {
     }
 
     const createTodo = () => {
-        const today = new Date();
         const newTodo: Todo = {
             id: uuidv4(),
             taskId: todoBuilderData.task.id,

--- a/web/src/features/todoFlow/TemplateFlow.tsx
+++ b/web/src/features/todoFlow/TemplateFlow.tsx
@@ -9,6 +9,7 @@ import { CategoryStep } from "./CategoryStep";
 import { TaskStep } from "./TaskStep";
 import { TypeStep } from "./TypeStep";
 import { DescriptionStep } from "./DescriptionStep";
+import { now } from "lodash";
 
 const TYPE_STEP = 'TYPE';
 const CATEGORY_STEP = 'CATEGORY';
@@ -63,11 +64,12 @@ const TemplateFlow = () => {
     }
 
     const createTodo = () => {
+        const today = new Date();
         const newTodo: Todo = {
             id: uuidv4(),
             taskId: todoBuilderData.task.id,
             title: todoBuilderData.task.name,
-            createdAt: '28-10-22',
+            createdAt: Date.now(),
             type: todoBuilderData.type,
             description: todoBuilderData.description
         }

--- a/web/src/helpers/date.test.ts
+++ b/web/src/helpers/date.test.ts
@@ -1,6 +1,20 @@
-import { isDateThisMonth, isDateThisWeek, isDateToday } from "./date";
+import { Type } from "../interfaces/todo";
+import { filterDateForType, isDateThisMonth, isDateThisWeek, isDateToday } from "./date";
 
+it('test filterDateForType', () => {
+    const unixYesterday = Date.now() - 1000 * 60 * 60 * 24;
+    const unixLastWeek = Date.now() - 1000 * 60 * 60 * 24 * 8;
+    const unixLastMonth = Date.now() - 1000 * 60 * 60 * 24 * 40;
 
+    expect(filterDateForType(Type.daily, Date.now())).toBeTruthy();
+    expect(filterDateForType(Type.daily, unixYesterday)).toBeFalsy();
+
+    expect(filterDateForType(Type.daily, Date.now())).toBeTruthy();
+    expect(filterDateForType(Type.daily, unixLastWeek)).toBeFalsy();
+
+    expect(filterDateForType(Type.monthly, Date.now())).toBeTruthy();
+    expect(filterDateForType(Type.monthly, unixLastMonth)).toBeFalsy();
+})
 
 it('test isDateToday', () => {
     const unixYesterday = Date.now() - 1000 * 60 * 60 * 24;

--- a/web/src/helpers/date.test.ts
+++ b/web/src/helpers/date.test.ts
@@ -1,0 +1,23 @@
+import { isDateThisMonth, isDateThisWeek, isDateToday } from "./date";
+
+
+
+it('test isDateToday', () => {
+    const unixYesterday = Date.now() - 1000 * 60 * 60 * 24;
+    expect(isDateToday(Date.now())).toBeTruthy();
+    expect(isDateToday(unixYesterday)).toBeFalsy();
+})
+
+it('test isDateThisWeek', () => {
+    const unixLastWeek = Date.now() - 1000 * 60 * 60 * 24 * 8;
+
+    expect(isDateThisWeek(Date.now())).toBeTruthy();
+    expect(isDateThisWeek(unixLastWeek)).toBeFalsy();
+})
+
+it('test isDateThisMonth', () => {
+    const unixLastMonth = Date.now() - 1000 * 60 * 60 * 24 * 40;
+
+    expect(isDateThisMonth(Date.now())).toBeTruthy();
+    expect(isDateThisMonth(unixLastMonth)).toBeFalsy();
+})

--- a/web/src/helpers/date.ts
+++ b/web/src/helpers/date.ts
@@ -1,7 +1,6 @@
 import { Type } from "../interfaces/todo";
 
 const filterDateForType = (type: Type, unix: number) => {
-
     if (type === Type.daily) {
         return isDateToday(unix);
     }

--- a/web/src/helpers/date.ts
+++ b/web/src/helpers/date.ts
@@ -1,0 +1,45 @@
+import { Type } from "../interfaces/todo";
+
+const filterDateForType = (type: Type, unix: number) => {
+
+    if (type === Type.daily) {
+        return isDateToday(unix);
+    }
+
+    if (type === Type.weekly) {
+        return isDateThisWeek(unix);
+    }
+
+    return isDateThisMonth(unix);
+}
+
+
+const getWeek = (unix: number) => {
+    const temp = new Date();
+    const firstDayOfYear = new Date(temp.getFullYear(), 0, 1).getTime();
+    const dayOfYear = ((unix - firstDayOfYear + 86400000)/86400000);
+    return Math.ceil(dayOfYear/7)
+}
+
+const isDateToday = (unix: number): boolean => {
+    const a = new Date(unix);
+    const b = new Date();
+
+    return a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+}
+
+const isDateThisWeek = (unix: number) => {
+    return getWeek(Date.now()) === getWeek(unix);
+}
+
+const isDateThisMonth = (unix: number): boolean => {
+    const a = new Date(unix);
+    const b = new Date();
+
+    return a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth();
+}
+
+export { filterDateForType, isDateToday, isDateThisWeek, isDateThisMonth };

--- a/web/src/helpers/date.ts
+++ b/web/src/helpers/date.ts
@@ -13,12 +13,11 @@ const filterDateForType = (type: Type, unix: number) => {
     return isDateThisMonth(unix);
 }
 
-
 const getWeek = (unix: number) => {
     const temp = new Date();
     const firstDayOfYear = new Date(temp.getFullYear(), 0, 1).getTime();
-    const dayOfYear = ((unix - firstDayOfYear + 86400000)/86400000);
-    return Math.ceil(dayOfYear/7)
+    const dayOfYear = ((unix - firstDayOfYear + 86400000) / 86400000);
+    return Math.ceil(dayOfYear / 7)
 }
 
 const isDateToday = (unix: number): boolean => {
@@ -26,12 +25,16 @@ const isDateToday = (unix: number): boolean => {
     const b = new Date();
 
     return a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate();
+        a.getMonth() === b.getMonth() &&
+        a.getDate() === b.getDate();
 }
 
 const isDateThisWeek = (unix: number) => {
-    return getWeek(Date.now()) === getWeek(unix);
+    const now = new Date();
+    const inputDate = new Date(unix);
+
+    return now.getFullYear() === inputDate.getFullYear() &&
+        getWeek(now.getTime()) === getWeek(inputDate.getTime());
 }
 
 const isDateThisMonth = (unix: number): boolean => {
@@ -39,7 +42,7 @@ const isDateThisMonth = (unix: number): boolean => {
     const b = new Date();
 
     return a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth();
+        a.getMonth() === b.getMonth();
 }
 
 export { filterDateForType, isDateToday, isDateThisWeek, isDateThisMonth };

--- a/web/src/interfaces/todo.ts
+++ b/web/src/interfaces/todo.ts
@@ -3,7 +3,7 @@ interface Todo {
     title: string,
     taskId: string,
     description?: string,
-    createdAt: string,
+    createdAt: number,
     completedAt?: string,
     type: Type
 }


### PR DESCRIPTION
Added feature so that Todos are now time based. Todos are now only visible on the Dashboard if they are within the Type time slot eg. daily = today, weekly = this week, and monthly = this month.